### PR TITLE
Add handling for kc_action and kc_action_status in Keycloak OpenID an…

### DIFF
--- a/lib/omniauth/strategies/keycloak-openid.rb
+++ b/lib/omniauth/strategies/keycloak-openid.rb
@@ -126,10 +126,13 @@ module OmniAuth
             end
 
             extra do
-            {
+            hash = {
                 'raw_info' => raw_info,
                 'id_token' => access_token['id_token']
             }
+            hash['kc_action_status'] = session.delete("omniauth.kc_action_status") if session["omniauth.kc_action_status"]
+            hash['kc_action'] = session.delete("omniauth.kc_action") if session["omniauth.kc_action"]
+            hash
             end
 
             def raw_info

--- a/lib/omniauth/strategies/oauth2-multiple-state.rb
+++ b/lib/omniauth/strategies/oauth2-multiple-state.rb
@@ -69,8 +69,14 @@ module OmniAuth
         session["omniauth.state_origins"] ||= {}
         session["omniauth.state_origins"][params[:state]] = session['omniauth.origin']
 
+        if params[:kc_action]
+          session["omniauth.state_kc_actions"] ||= {}
+          session["omniauth.state_kc_actions"][params[:state]] = params[:kc_action]
+        end
+
         session['omniauth.states'] = session['omniauth.states'].last(5) if session["omniauth.states"].length > 5
         session['omniauth.state_origins'] = session['omniauth.state_origins'].to_a.last(5).to_h if session["omniauth.state_origins"].length > 5
+        session['omniauth.state_kc_actions'] = session['omniauth.state_kc_actions'].to_a.last(5).to_h if session["omniauth.state_kc_actions"] && session["omniauth.state_kc_actions"].length > 5
 
         params
       end
@@ -90,8 +96,17 @@ module OmniAuth
         self.access_token = build_access_token
         self.access_token = access_token.refresh! if access_token.expired?
       
+        if request.params["kc_action_status"]
+          session["omniauth.kc_action_status"] = request.params["kc_action_status"]
+        end
+        
         if session["omniauth.state_origins"] && request.params["state"]
           env["omniauth.origin"] = session["omniauth.state_origins"].delete(request.params["state"])
+        end
+
+        if session["omniauth.state_kc_actions"] && request.params["state"]
+          kc_action = session["omniauth.state_kc_actions"].delete(request.params["state"])
+          session["omniauth.kc_action"] = kc_action if kc_action
         end
       
         super


### PR DESCRIPTION
…d OAuth2 Multiple State strategies

- Updated Keycloak OpenID strategy to include kc_action and kc_action_status in the extra hash.
- Enhanced OAuth2 Multiple State strategy to store and manage kc_action and kc_action_status in the session.
- Improved session management for kc_action states to maintain clarity in the authentication flow.